### PR TITLE
feat: Update Changelog

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -34,6 +34,12 @@ const commitUrl = import.meta.env.CF_PAGES_COMMIT_SHA
           {commitHash}
         </Link>
       </p>
+      <Separator orientation="vertical" className="hidden h-4! sm:block" />
+      <a href="https://github.com/miz77/miz7net" target="_blank" rel="noopener noreferrer">
+      <img src="https://img.shields.io/badge/GitHub-miz7.net-6495ED?logo=github" alt="GitHubでmiz7.netを見る">
+      </a>
+
+
     </div>
     <SocialIcons links={SOCIAL_LINKS} />
   </div>

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -40,6 +40,10 @@ const commitHash = import.meta.env.CF_PAGES_COMMIT_SHA?.slice(0, 7) || 'local'
         /Authors へ Spotify の直近の再生履歴を追加。<br>Thanks to spotify-recently-played-readme.vercel.app.
         </li>
          <br>
+        <li> 
+        miz7netリポジトリを Private -> Publicへ移行。これに伴い、ページのフッターに本サイトのリポジトリへのリンクを追加。
+        </li>
+         <br>
       </ul>
     </article>
 

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -19,7 +19,7 @@ const commitHash = import.meta.env.CF_PAGES_COMMIT_SHA?.slice(0, 7) || 'local'
       
       <ul class="list-disc pl-5">
         <li> 
-        About ページに 334 Clock の GitHub リポジトリ及び Chrome Web Store へのリンクを追加。
+        About ページへ 334 Clock の GitHub リポジトリ及び Chrome Web Store へのリンクを追加。
         <br>
         <br>
         </li>
@@ -167,7 +167,7 @@ const commitHash = import.meta.env.CF_PAGES_COMMIT_SHA?.slice(0, 7) || 'local'
       </label>
 
       <label class="flex items-center gap-x-2">
-        <span class="custom-checkbox"></span>
+        <span class="custom-checkbox is-checked"></span>
         miz7netリポジトリをパブリックへ移す。
       </label>
 


### PR DESCRIPTION
Changelog を更新。

## 2025年7月31日


###  追加

* About ページへ 334 Clock の GitHub リポジトリ及び Chrome Web Store へのリンクを追加。
* Authors ページへ Spotify の直近の再生履歴を追加。<br>Thanks to spotify-recently-played-readme.vercel.app.
* フッターへ本サイトの GitHub リポジトリへのリンクを追加。

### 変更 

*  334 Clock ページのリファクタリングを実施。
    * 他ページとレイアウトを統一するため、共通の`Layout`コンポーネントを使用するように変更。
    * ダークモードを実装。
    * 背景色(#ffffff)とのコントラスト比を上げるため、一部ボタンの配色を変更。
*  334 Clock ページで"tools"をクリックした際に、About ページへリダイレクトするように変更しました。
*   miz7net リポジトリを Private -> Publicへ移行。

###  修正 

* トップページから 334 Clock ページへ遷移した後もアニメーションが続いてしまう問題を、`data-astro-reload`属性を付与して修正。

