### PR TITLE
feat: Update Changelog

### DIFF
--- a/src/components/Exam-Timer.astro
+++ b/src/components/Exam-Timer.astro
@@ -2,9 +2,7 @@
 // src/components/Exam-Timer.astro
 
 
-const presets = {
-  '電工二種・技能試験': { start: '11:30', end: '12:10' },
-};
+import { presets } from '@/lib/timer-presets.ts';
 ---
 
 <div id="exam-clock-wrapper">
@@ -92,6 +90,7 @@ const presets = {
 </style>
 
 <script>
+  import { presets } from '../lib/timer-presets.ts'; 
   import { ExamTimer } from '../lib/timerLogic.ts';
   import type { TimerState } from '../lib/timerLogic.ts';
 
@@ -113,9 +112,6 @@ const presets = {
   const closeAlarmBtn = document.getElementById('close-alarm-btn')!;
   const alarmSound = document.getElementById('alarm-sound') as HTMLAudioElement;
 
-   const presets: Record<string, { start: string; end: string; }> = {
-    '電工二種・技能試験': { start: '11:30', end: '12:10' },
-  };
 
   let accumulatedSecondDeg = 0;
   let accumulatedMinuteDeg = 0;
@@ -255,13 +251,13 @@ const presets = {
   });
 
   presetSelect.addEventListener('change', () => {
-    const presetName = presetSelect.value;
-    if (presetName in presets) {
-      startTimeInput.value = presets[presetName].start;
-      endTimeInput.value = presets[presetName].end;
-      updateTimesFromInputs();
-    }
-  });
+  const key = presetSelect.value;
+  if (key in presets) {
+    startTimeInput.value = presets[key].start;
+    endTimeInput.value   = presets[key].end;
+    updateTimesFromInputs();
+  }
+});
   
   closeAlarmBtn.addEventListener('click', () => {
     alarmModal.classList.add('hidden');

--- a/src/lib/timer-presets.ts
+++ b/src/lib/timer-presets.ts
@@ -1,0 +1,10 @@
+// src/lib/presets.ts
+export interface Preset {
+  start: string
+  end:   string
+}
+
+export const presets: Record<string,Preset> = {
+  '電工二種・技能試験': { start: '11:30', end: '12:10' },
+  // 他のプリセットもいつかここに追加しようと思うけど、数が増えてくると現状のUIではだめそうということに気づいてしまった。
+}

--- a/src/pages/changelog/index.astro
+++ b/src/pages/changelog/index.astro
@@ -14,8 +14,24 @@ const commitHash = import.meta.env.CF_PAGES_COMMIT_SHA?.slice(0, 7) || 'local'
     <h1 class="text-3xl font-medium">Changelog</h1>
 
     <article class="flex flex-col gap-y-2">
-      <h2 class="text-2xl font-medium">2025年8月2日</h2>
+      <h2 class="text-2xl font-medium">2025年8月3日</h2>
       <p class="text-1xl text-muted-foreground"> Commit <span class="font-mono">{commitHash}</span> </p>
+      
+      <ul class="list-disc pl-5">
+        <li> 
+        Exam Timer に関してリファクタリングを実施。 <br>
+        + デジタル庁デザインシステムβ版 v2.6.0 で定義済みのプリミティブカラー、セマンティックカラー、リンクカラーの組み合わせ例を参考にボタンの配色を変更。<br>
+        + `Exam-Timer.astro`内での複数のスタイルによる衝突を解消。<br>
+        + 試験プリセットの定義の外部モジュール化を実施。
+        </li>
+        <br>
+
+      </ul>
+    </article>
+
+    <article class="flex flex-col gap-y-2">
+      <h2 class="text-2xl font-medium">2025年8月2日</h2>
+      <p class="text-1xl text-muted-foreground"> Commit <span class="font-mono">1e2bfdf</span> </p>
       
       <ul class="list-disc pl-5">
         <li> 


### PR DESCRIPTION
Changelog を更新。すべて`Exam Timer`に関わる変更。
## 2025年8月3日

### 変更
+ Exam Timer のリファクタリング
   + デジタル庁デザインシステムβ版 v2.6.0 で定義済みのプリミティブカラー、セマンティックカラー、リンクカラーの組み合わせ例を参考にボタンの配色を変更。

   + JIS X 8341-3:2016 および WCGA 2.1, 2.2 で求められるコントラスト要件レベル AAA を目標に文字色を変更。リセットボタンと、ナイトモード時の「試験開始」ボタンを除いて達成。

https://github.com/user-attachments/assets/2aaa3399-d8d7-4416-b19b-5cc8f18eb980





+ 試験プリセットの定義の外部モジュール化に伴うロジックの変更。




### 追加

+ 試験プリセット定義のモジュール化に伴い、参照する外部ファイルを追加。 (`@/lib/timer-presets.ts`)


### 修正
+ CSSスタイルの衝突を解消
   + `Exam-Timer.astro` で、JavaScriptによるクラス変更が意図せず他のスタイルを上書きしてしまう問題を、状態（タイマー停止中 or 作動中）に応じて適用するクラスのセットを明確に管理することで回避。